### PR TITLE
Added dashboard button with icon to feedback page

### DIFF
--- a/public/feedback.html
+++ b/public/feedback.html
@@ -596,6 +596,32 @@
             <div>Pending: 3</div>
           </div>
         </div>
+
+        <!-- Navigation Link to dashboard added  -->
+        <div
+                    class="p-3 rounded-lg bg-brown-100 border border-yellow-300 hover:bg-gray-100 transition-colors"
+                >
+                    <a
+                        href="index.html"
+                        class="flex items-center space-x-2 text-black-700 hover:text-blue-600"
+                    >
+                        <svg
+                         xmlns="http://www.w3.org/2000/svg"
+                         fill="none"
+                         viewBox="0 0 24 24"
+                         stroke="currentColor"
+                         class="w-5 h-5"
+                       >
+                       <path
+                         stroke-linecap="round"
+                         stroke-linejoin="round"
+                         stroke-width="2"
+                         d="M3 3h7v7H3V3zM14 3h7v7h-7V3zM3 14h7v7H3v-7zM14 14h7v7h-7v-7z"
+                       />
+                        </svg>
+                        <span>Dashboard</span>
+                    </a>
+                </div>
         </div>
     </aside>
 


### PR DESCRIPTION
 This PR Closes issue #58 
Added a new **Dashboard** button alongside the existing Feedback button on the feedback page. This improves navigation by allowing users to quickly access the dashboard.

**Changes:**  
- Added a dashboard icon SVG embedded inline.  
- Styled the button consistent with the existing UI using Tailwind classes.  
- Linked the button to `dashboard.html`.

**Branch:** `feature/add-dashboard-btn`

Before : 
<img width="1907" height="867" alt="Screenshot 2025-08-10 234744" src="https://github.com/user-attachments/assets/96b23b82-dc2f-4b3d-93e3-b5ac33cbeb6b" />

After : 
<img width="861" height="745" alt="btn aded" src="https://github.com/user-attachments/assets/ac6eb56b-d11b-4aae-b255-b5a903bfb67a" />


@Forkzen Please review and close issue #58 